### PR TITLE
chore(dns): delete duck-invaders.fr dns zones

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -9,17 +9,6 @@ module "awsworkshop_paris-zones" {
   env_dns_zones_prefix = var.env_dns_zones_prefix
 }
 
-# duck-invaders.fr
-module "duck-invaders_fr-zones" {
-  source = "github.com/VEBERArnaudAWS/tf_module-dns_zones?ref=v0.0.2-alpha.5"
-
-  bypass = terraform.workspace != "prd" ? true : false
-
-  domain               = "duck-invaders.fr"
-  env_names            = var.env_names
-  env_dns_zones_prefix = var.env_dns_zones_prefix
-}
-
 # grantueismo.world
 module "granturismo_world-zones" {
   source = "github.com/VEBERArnaudAWS/tf_module-dns_zones?ref=v0.0.2-alpha.5"


### PR DESCRIPTION
# Description

delete duck-invaders.fr dns zones

---

| Q              | A
| -------------- | ---
| Bug fix ?      | no
| New feature ?  | no
| BC breaks ?    | no
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | 
| License        | MIT
